### PR TITLE
Use Mixin for common class resolving

### DIFF
--- a/src/main/java/net/gudenau/minecraft/asm/impl/Bootstrap.java
+++ b/src/main/java/net/gudenau/minecraft/asm/impl/Bootstrap.java
@@ -55,7 +55,6 @@ public class Bootstrap{
         
         // Hack into knot.
         ClassLoader classLoader = Bootstrap.class.getClassLoader();
-        MixinTransformer.setClassLoader(classLoader); // Needed for ASM, don't ask
         
         try{
             // Get classes we can't normally access

--- a/src/main/java/net/gudenau/minecraft/asm/impl/MixinTransformer.java
+++ b/src/main/java/net/gudenau/minecraft/asm/impl/MixinTransformer.java
@@ -29,6 +29,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.transformer.FabricMixinTransformerProxy;
 import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
+import org.spongepowered.asm.transformers.MixinClassWriter;
 
 /**
  * Our custom "mixin" transformer.
@@ -61,12 +62,6 @@ public class MixinTransformer extends FabricMixinTransformerProxy{
             // Unreachable, makes javac happy
             throw new RuntimeException("Failed to get ClassLoader.defineClass1", e);
         }
-    }
-    
-    private static ClassLoader classLoader;
-    
-    public static void setClassLoader(ClassLoader classLoader){
-        MixinTransformer.classLoader = classLoader;
     }
     
     private final Set<String> seenClasses = new HashSet<>();
@@ -196,13 +191,7 @@ public class MixinTransformer extends FabricMixinTransformerProxy{
             return bytecode;
         }
         
-        ClassWriter writer = new ClassWriter(flags.getClassWriterFlags()){
-            // Fixes an issue with stack calculations
-            @Override
-            protected ClassLoader getClassLoader(){
-                return classLoader;
-            }
-        };
+        ClassWriter writer = new MixinClassWriter(flags.getClassWriterFlags());
         classNode.accept(writer);
         parentModifier.set(true);
         return writer.toByteArray();


### PR DESCRIPTION
This PR Change `ClassWriter` to use the Mixin Implementation instead of the ASM Implementation

Mixin implementation don't load classes to resolve common classes but compare the unloaded bytecode

It completely prevent any `ClassCircularityError` by making `COMPUTE_FRAMES` no longer call `loadClass` making it a lot safer than the current implementation of `ClassWriter` in `gudASM`

